### PR TITLE
Specify extra.drush.services in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,12 @@
     "composer/installers": "~1.0"
   },
   "extra": {
-    "installer-name": "potx"
+    "installer-name": "potx",
+    "drush": {
+      "services": {
+        "drush.services.yml": "^9"
+      }
+    }
   },
   "type":"drupal-module"
 }


### PR DESCRIPTION
Hello there!

Using your d8 port with great success on several projects. Thanks alot!

For drush 9 a warning has been appearing for a while now, and it is the following:

```
potx should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file.
```

This PR fixes that.

Thanks again for making this, and keep up the good work!