### PR TITLE
Avoid writing invalid plural headers

### DIFF
--- a/potx.inc
+++ b/potx.inc
@@ -688,9 +688,6 @@ function _potx_get_header($file, $template_export_langcode = NULL, $api_version 
   if (isset($language->formula) && isset($language->plurals)) {
     $output .= "\"Plural-Forms: nplurals=". $language->plurals ."; plural=". strtr($language->formula, array('$' => '')) .";\\n\"\n\n";
   }
-  else {
-    $output .= "\"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n\"\n\n";
-  }
   return $output;
 }
 


### PR DESCRIPTION
Currently, this module will write a header like so to all its language files:

``` 
"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
```
this in turn will get parsed by the poDatabaseWriter and written to state as the pluralFormula for the language in the file. This in turn will end up destroying javascript translation, since the pluralFormula will now be set to:

```
Array
(
    [nb] => Array
        (
            [plurals] => INTEGER
            [formula] => Array
                (
                    [default] => 0
                )

        )

)
``` 
when we really want it to be set to 

```
Array
(
    [nb] => Array
        (
            [plurals] => 2
            [formula] => Array
                (
                    [1] => 0
                    [default] => 1
                )

        )

)
```

This is easily solved by importing a file with a correct header, but that is a workaround for the problem. This module should not write an invalid header destroying a plural formula for a language :)

Here is a PR just removing that line, since it has no actual use AFAIK